### PR TITLE
fix: User table name set

### DIFF
--- a/src/main/java/com/eouil/bank/bankapi/domains/User.java
+++ b/src/main/java/com/eouil/bank/bankapi/domains/User.java
@@ -1,13 +1,11 @@
 package com.eouil.bank.bankapi.domains;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
 @Entity
+@Table(name = "users")
 @Getter@Setter
 public class User {
     @Id @GeneratedValue


### PR DESCRIPTION
- [x] JPA에게 user는 테이블 이름을 그대로 SQL 사용하는 예약어임. 이로 인한 SQL 문법 오류 충돌 방지를 위해 테이블명 users로 추가 세팅