### PR TITLE
test: Add AccountService unit tests for createAccount

### DIFF
--- a/src/test/java/com/eouil/bank/bankapi/AccountServiceTest.java
+++ b/src/test/java/com/eouil/bank/bankapi/AccountServiceTest.java
@@ -1,0 +1,87 @@
+package com.eouil.bank.bankapi;
+
+import com.eouil.bank.bankapi.domains.Account;
+import com.eouil.bank.bankapi.domains.User;
+import com.eouil.bank.bankapi.dtos.requests.CreateAccountRequest;
+import com.eouil.bank.bankapi.dtos.responses.CreateAccountResponse;
+import com.eouil.bank.bankapi.repositories.AccountRepository;
+import com.eouil.bank.bankapi.repositories.UserRepository;
+import com.eouil.bank.bankapi.services.AccountService;
+import com.eouil.bank.bankapi.utils.JwtUtil;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AccountServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @InjectMocks
+    private AccountService accountService;
+
+    private final String token = "mock.jwt.token";
+    private final String userId = "user-123";
+    private User mockUser;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = new User();
+        mockUser.setUserId(userId);
+    }
+
+    @Test
+    void createAccount_success() {
+        CreateAccountRequest request = new CreateAccountRequest();
+        request.setUserId(1L); // 테스트에서는 사용 안 함
+        request.setBalance(new BigDecimal("100000"));
+
+        try (MockedStatic<JwtUtil> mockedJwt = mockStatic(JwtUtil.class)) {
+            mockedJwt.when(() -> JwtUtil.validateTokenAndGetUserId(token)).thenReturn(userId);
+
+            when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+            when(accountRepository.existsByAccountNumber(anyString())).thenReturn(false);
+
+            CreateAccountResponse response = accountService.createAccount(request, token);
+
+            assertNotNull(response.getAccountNumber());
+            assertEquals(userId, response.getUserId());
+            assertEquals(request.getBalance(), response.getBalance());
+            assertNotNull(response.getCreatedAt());
+
+            verify(accountRepository).save(any(Account.class));
+        }
+    }
+
+    @Test
+    void createAccount_userNotFound_shouldThrowException() {
+        CreateAccountRequest request = new CreateAccountRequest();
+        request.setBalance(new BigDecimal("100000"));
+
+        try (MockedStatic<JwtUtil> mockedJwt = mockStatic(JwtUtil.class)) {
+            mockedJwt.when(() -> JwtUtil.validateTokenAndGetUserId(token)).thenReturn(userId);
+            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+            RuntimeException ex = assertThrows(RuntimeException.class, () ->
+                    accountService.createAccount(request, token));
+
+            assertEquals("User not found", ex.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/eouil/bank/bankapi/AuthServiceTest.java
+++ b/src/test/java/com/eouil/bank/bankapi/AuthServiceTest.java
@@ -1,4 +1,4 @@
-package com.eouil.bank.bankapi.controllers;
+package com.eouil.bank.bankapi;
 
 
 import com.eouil.bank.bankapi.domains.User;


### PR DESCRIPTION
AccountService의 createAccount 메서드에 대한 단위 테스트 추가
- 계좌 정상 생성, 사용자 없음 예외 처리 테스트
- JWT 토큰 처리 : JwtUtil.validateTokenAndGetUserId 정적 메서드 MockedStatic으로 모킹
- 사용자 정보 및 계좌 저장 로직: UserRepository, AccountRepository 모킹 처리

