### PR TITLE
refactor: password encoding applied into /join, /login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 	testImplementation 'org.mockito:mockito-inline:4.11.0'
 
 	implementation 'com.h2database:h2' //개발용
+	implementation 'org.springframework.boot:spring-boot-starter-security' // encoder 암호화용
 }
 
 tasks.named('test') {

--- a/src/main/java/com/eouil/bank/bankapi/config/SecurityConfig.java
+++ b/src/main/java/com/eouil/bank/bankapi/config/SecurityConfig.java
@@ -1,0 +1,34 @@
+package com.eouil.bank.bankapi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .headers(headers -> headers.frameOptions(frame -> frame.disable())) // ✅ 최신 방식
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/join", "/login", "/h2-console/**").permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
- [x] POST /join api에 password 입력시 db에 암호화된채 저장되는 encoding 로직 추가 완료
- [x] POST /login api에 password 입력시 db에 암호화된채 저장되는 encoding 로직 추가 완료