### PR TITLE
fix: joinResponse edited in /join

### DIFF
--- a/src/main/java/com/eouil/bank/bankapi/dtos/responses/JoinResponse.java
+++ b/src/main/java/com/eouil/bank/bankapi/dtos/responses/JoinResponse.java
@@ -1,12 +1,10 @@
 package com.eouil.bank.bankapi.dtos.responses;
 
 public class JoinResponse {
-    public String userId;
     public String name;
     public String email;
 
-    public JoinResponse(String userId, String name, String email) {
-        this.userId = userId;
+    public JoinResponse(String name, String email) {
         this.name = name;
         this.email = email;
     }

--- a/src/main/java/com/eouil/bank/bankapi/services/AuthService.java
+++ b/src/main/java/com/eouil/bank/bankapi/services/AuthService.java
@@ -44,7 +44,7 @@ public class AuthService {
 
         userRepository.save(user);
 
-        return new JoinResponse(user.getUserId(), user.getName(), user.getEmail());
+        return new JoinResponse(user.getName(), user.getEmail());
     }
 
     public LoginResponse login(LoginRequest loginRequest) {


### PR DESCRIPTION
- [x] /join API의 joinResponse에서 userId 제거