### PR TITLE
feat: OTEL 기반 모니터링 설정 및 Collector 연동Feature/otel monitoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,55 +1,86 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.4'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.3'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.eouil.bank'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency { details ->
+        if (details.requested.group == 'io.opentelemetry' &&
+            !details.requested.name.contains('incubator')) {
+            details.useVersion '1.49.0'
+        }
+
+        if (details.requested.group == 'io.opentelemetry.instrumentation' &&
+            details.requested.name == 'opentelemetry-spring-boot-starter') {
+            details.useVersion '2.14.0'
+        }
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'jakarta.validation:jakarta.validation-api:3.0.0'
-	implementation 'org.hibernate.validator:hibernate-validator:6.1.5.Final'
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    // Spring
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security' // encoder 암호화용
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+
+    // DB
+    implementation 'com.mysql:mysql-connector-j:8.0.33'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'com.h2database:h2' // 개발용
+
+    // Validation & JWT
+    implementation 'jakarta.validation:jakarta.validation-api:3.0.0'
+    implementation 'org.hibernate.validator:hibernate-validator:6.2.5.Final'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-	compileOnly 'org.projectlombok:lombok'
-	implementation 'com.mysql:mysql-connector-j:8.0.33'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	testImplementation 'org.mockito:mockito-junit-jupiter:4.11.0'
-	testImplementation 'org.mockito:mockito-inline:4.11.0'
+    // dotenv 환경변수 적용
+    implementation 'io.github.cdimascio:java-dotenv:5.2.2'
 
-	implementation 'com.h2database:h2' //개발용
-	implementation 'org.springframework.boot:spring-boot-starter-security' // encoder 암호화용
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	implementation 'org.hibernate.validator:hibernate-validator:6.2.5.Final' // validation
-//	implementation 'io.github.cdimascio:java-dotenv:5.2.2' // 환경변수 적용
+    // OpenTelemetry (Core + Spring Boot Starter)
+    implementation 'io.opentelemetry:opentelemetry-api:1.49.0'
+    implementation 'io.opentelemetry:opentelemetry-sdk:1.49.0'
+    implementation 'io.opentelemetry:opentelemetry-exporter-otlp:1.49.0'
+    implementation 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.49.0'
+    implementation 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:1.49.0'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter:2.14.0'
+
+
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.mockito:mockito-junit-jupiter:4.11.0'
+    testImplementation 'org.mockito:mockito-inline:4.11.0'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/monitoring/collector-config.yaml
+++ b/monitoring/collector-config.yaml
@@ -1,0 +1,26 @@
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
+
+  exporters:
+    awsxray:
+      region: ap-northeast-2
+    awscloudwatchlogs:
+      log_group_name: "/otel/bankapi"
+      log_stream_name: "otel-log-stream"
+      region: ap-northeast-2
+    debug:
+      verbosity: detailed
+
+  service:
+    pipelines:
+      traces:
+        receivers: [otlp]
+        exporters: [debug, awsxray]
+      logs:
+        receivers: [otlp]
+        exporters: [debug, awscloudwatchlogs]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,11 +5,11 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
-      minimum-idle: 3           # 최소 유휴 커넥션 수
-      maximum-pool-size: 10     # 최대 커넥션 수 (DB 성능에 따라 조절)
-      idle-timeout: 30000       # 유휴 상태 유지 시간 (30초)
-      max-lifetime: 600000      # 커넥션 최대 생존 시간 (10분)
-      connection-timeout: 30000 # 커넥션 획득 대기 시간 (30초)
+      minimum-idle: 3
+      maximum-pool-size: 10
+      idle-timeout: 30000
+      max-lifetime: 600000
+      connection-timeout: 30000
 
   jpa:
     hibernate:
@@ -17,4 +17,33 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics
+  tracing:
+    enabled: true
+  otlp:
+    metrics:
+      export:
+        enabled: false
+    logs:
+      export:
+        enabled: false
+
+otel:
+  exporter:
+    otlp:
+      endpoint: http://localhost:4317
+  service:
+    name: bankapi-service
+
+logging:
+  level:
+    root: INFO
+    com.eouil.bank.bankapi: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE


### PR DESCRIPTION
## 🔧 작업 내용

- OpenTelemetry Collector 설정 파일 추가 (`monitoring/collector-config.yaml`)
- Spring Boot 애플리케이션에 OTEL SDK 연동
  - OTLP Exporter 설정 (`localhost:4317`)
  - 서비스 이름 `bankapi-service` 지정
- build.gradle에 OTEL 관련 라이브러리 추가
- OTEL Java Agent (`opentelemetry-javaagent.jar`) 프로젝트에 포함
- application.yml에서 DB 설정 환경변수로 분리 (`${DB_URL}` 등)


## 🧪 테스트 내역

- 로컬 환경에서 OTEL Collector와 연동하여 trace 및 logs 수집 확인
- OTLP 포트를 통한 Collector 수신 정상 확인 (4317 gRPC)
- Spring Boot → OTEL → CloudWatch 로그 흐름 정상 작동


## 🎯 향후 작업 (배포 관련)

- ECS Task 정의에 OTEL Collector Sidecar 포함 필요
- OTEL Collector config 파일은 `/etc/otel/otel-collector-config.yaml` 경로로 mount

## ✅ 기타

- `build.gradle` 충돌 해결 완료 (중복 의존성 정리)
