### PR TITLE
fix: enable OpenTelemetry logging with logback and YAML config

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,7 +32,7 @@ management:
         enabled: false
     logs:
       export:
-        enabled: false
+        enabled: true
 
 otel:
   exporter:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- OpenTelemetry 로그 전송용 Appender -->
+    <appender name="OTEL" class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 콘솔 출력도 같이 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="OTEL" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
## ✅ Changes

- application.yaml 파일에서 OTLP 로그 내보내기(log export)를 활성화
- logback-spring.xml 파일을 추가하고 OpenTelemetryAppender를 설정
- 로그가 OTEL Collector를 거쳐 CloudWatch Logs로 전송되도록 구성
- 변경 사항을 반영한 Docker 이미지를 재빌드하고, ECS 태스크 정의를 업데이트할 것