### PR TITLE
fix: update OTEL collector endpoint from service name to EC2 public IP

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,7 @@ management:
     logs:
       export:
         enabled: true
-    endpoint: http://otel-collector:4318  # 4317에서 4318로 변경
+    endpoint: http://3.35.210.176:4318  # 4317에서 4318로 변경
     protocol: http/protobuf  # grpc에서 http/protobuf로 변경
 
 otel:


### PR DESCRIPTION
### 변경 사항
- OTEL Collector를 ECS 태스크의 사이드카 방식에서 독립 EC2로 분리
- Collector endpoint를 실제 EC2 public IP로 변경
  - 변경 전: `http://otel-collector:4318`
  - 변경 후: `http://3.35.210.176:4318`

### 변경 이유
- 컨테이너 간 네트워크 통신 문제 해결
- Collector 설정 변경 시 애플리케이션 재배포 불필요
- 리소스 분리로 인한 안정성 향상
- 모니터링 인프라 독립성 확보

### 추가 컨텍스트
OTEL Collector를 독립 EC2로 분리하여 더 안정적인 모니터링 인프라 구축